### PR TITLE
Handle microphone permission checks before WakeService starts

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/BootBroadcastReceiver.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/BootBroadcastReceiver.kt
@@ -1,5 +1,6 @@
 package org.stypox.dicio.io.wake
 
+import android.Manifest.permission.FOREGROUND_SERVICE_MICROPHONE
 import android.Manifest.permission.RECORD_AUDIO
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -7,17 +8,31 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
+import android.widget.Toast
 import androidx.core.content.ContextCompat
+import org.stypox.dicio.R
 
 class BootBroadcastReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d(TAG, "Got intent ${intent.action}")
 
-        if (ContextCompat.checkSelfPermission(context, RECORD_AUDIO) !=
-            PackageManager.PERMISSION_GRANTED) {
-            Log.d(TAG, "Audio permission not granted")
-            return
+        val permissions = mutableListOf(RECORD_AUDIO)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            permissions += FOREGROUND_SERVICE_MICROPHONE
+        }
+        for (permission in permissions) {
+            if (ContextCompat.checkSelfPermission(context, permission) !=
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                Log.d(TAG, "Audio permission not granted: $permission")
+                Toast.makeText(
+                    context,
+                    R.string.grant_microphone_permission,
+                    Toast.LENGTH_LONG,
+                ).show()
+                return
+            }
         }
 
         try {

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/WakeWordWidget.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/WakeWordWidget.kt
@@ -36,8 +36,12 @@ import org.stypox.dicio.ui.util.WakeStatesPreviews
 import org.stypox.dicio.ui.util.loadingProgressString
 
 val wakeWordPermissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    arrayOf(Manifest.permission.RECORD_AUDIO, Manifest.permission.POST_NOTIFICATIONS,
-            Manifest.permission.USE_FULL_SCREEN_INTENT)
+    arrayOf(
+        Manifest.permission.RECORD_AUDIO,
+        Manifest.permission.FOREGROUND_SERVICE_MICROPHONE,
+        Manifest.permission.POST_NOTIFICATIONS,
+        Manifest.permission.USE_FULL_SCREEN_INTENT,
+    )
 else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
     arrayOf(Manifest.permission.RECORD_AUDIO, Manifest.permission.POST_NOTIFICATIONS)
 else


### PR DESCRIPTION
## Summary
- Validate microphone recording and foreground-service permissions before starting `WakeService`
- Catch `SecurityException` when raising the foreground notification
- Request the new microphone foreground permission in wake-word setup

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_688f6026fa608321a96de9ccb3292fa5