### PR TITLE
Delay wake service foreground start until permissions verified

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
@@ -63,7 +63,6 @@ class WakeService : Service() {
     override fun onCreate() {
         super.onCreate()
         notificationManager = getSystemService(this, NotificationManager::class.java)!!
-        createForegroundNotification()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -89,6 +88,7 @@ class WakeService : Service() {
             return START_NOT_STICKY
         }
 
+        createForegroundNotification()
         startListening()
         return START_STICKY
     }


### PR DESCRIPTION
## Summary
- Ensure WakeService starts foreground mode only after microphone-related permissions have been granted.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6369aaac8321b90818fda92a9b0b