### PR TITLE
Fix wake word case sensitivity

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
@@ -125,8 +125,9 @@ class WakeService : Service() {
         val text = utterance.first
         val confidence = utterance.second
         val lower = text.lowercase(Locale.getDefault())
-        if (lower.startsWith(TRIGGER_WORD)) {
-            val command = text.substring(TRIGGER_WORD.length).trim()
+        val triggerWord = TRIGGER_WORD.lowercase(Locale.getDefault())
+        if (lower.startsWith(triggerWord)) {
+            val command = text.substring(triggerWord.length).trim()
             if (command.isNotEmpty()) {
                 skillEvaluator.processInputEvent(
                     InputEvent.Final(listOf(Pair(command, confidence)))


### PR DESCRIPTION
## Summary
- process wake word regardless of case so commands trigger only after "Джарвис"

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689062f2ea888321a54a649bdfe99847