### PR TITLE
Fix wake word handling and silence non-triggered speech

### DIFF
--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
@@ -8,7 +8,10 @@ import org.stypox.dicio.io.input.SttState
 class FakeSttInputDeviceWrapper : SttInputDeviceWrapper {
     override val uiState: MutableStateFlow<SttState> = MutableStateFlow(SttState.NotInitialized)
 
-    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean {
+    override fun tryLoad(
+        thenStartListeningEventListener: ((InputEvent) -> Unit)?,
+        playSound: Boolean,
+    ): Boolean {
         return true
     }
 

--- a/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
@@ -42,7 +42,11 @@ interface SttInputDeviceWrapper {
     val uiState: StateFlow<SttState?>
 
     // Пытается загрузить устройство. Если передан обработчик, то сразу начинает слушать.
-    fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean
+    // playSound указывает, воспроизводить ли звук начала прослушивания.
+    fun tryLoad(
+        thenStartListeningEventListener: ((InputEvent) -> Unit)?,
+        playSound: Boolean = true,
+    ): Boolean
 
     // Останавливает прослушивание.
     fun stopListening()
@@ -71,7 +75,7 @@ class SttInputDeviceWrapperImpl(
     private val _uiState: MutableStateFlow<SttState?> = MutableStateFlow(null)
     override val uiState: StateFlow<SttState?> = _uiState
     private var uiStateJob: Job? = null
-
+    private var playListeningSoundNextTime = true
 
     init {
         // Выполняем блокирующее чтение, потому что DataStore доступен сразу.
@@ -131,7 +135,10 @@ class SttInputDeviceWrapperImpl(
                 newSttInputDevice.uiState.collect {
                     _uiState.emit(it)
                     if (it == SttState.Listening) {
-                        playSound(R.raw.listening_sound)
+                        if (playListeningSoundNextTime) {
+                            playSound(R.raw.listening_sound)
+                        }
+                        playListeningSoundNextTime = true
                     }
                 }
             }
@@ -168,12 +175,16 @@ class SttInputDeviceWrapperImpl(
     }
 
     // Загружает устройство и при необходимости начинает слушать пользователя.
-    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean {
+    override fun tryLoad(
+        thenStartListeningEventListener: ((InputEvent) -> Unit)?,
+        playSound: Boolean,
+    ): Boolean {
         val listener = if (thenStartListeningEventListener != null) {
             wrapEventListener(thenStartListeningEventListener)
         } else null
 
         val device = sttInputDevice ?: return false
+        playListeningSoundNextTime = playSound
         val loaded = device.tryLoad(listener)
         if (!loaded && listener != null) {
             // Automatically trigger download and loading of the model if it is not ready yet.

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
@@ -114,33 +114,36 @@ class WakeService : Service() {
             }
             InputEvent.None -> restartListening()
             is InputEvent.Final -> {
-                handleFinalEvent(event)
-                restartListening()
+                val triggered = handleFinalEvent(event)
+                restartListening(playSound = triggered)
             }
         }
     }
 
-    private fun handleFinalEvent(event: InputEvent.Final) {
-        val utterance = event.utterances.firstOrNull() ?: return
+    private fun handleFinalEvent(event: InputEvent.Final): Boolean {
+        val utterance = event.utterances.firstOrNull() ?: return false
         val text = utterance.first
         val confidence = utterance.second
         val lower = text.lowercase(Locale.getDefault())
-        if (lower.startsWith(TRIGGER_WORD)) {
-            val command = text.substring(TRIGGER_WORD.length).trim()
+        val triggerWord = TRIGGER_WORD.lowercase(Locale.getDefault())
+        if (lower.startsWith(triggerWord)) {
+            val command = text.substring(triggerWord.length).trim()
             if (command.isNotEmpty()) {
                 skillEvaluator.processInputEvent(
                     InputEvent.Final(listOf(Pair(command, confidence)))
                 )
                 openMainActivity()
+                return true
             }
         }
+        return false
     }
 
-    private fun restartListening() {
+    private fun restartListening(playSound: Boolean = true) {
         if (listening.get()) {
             handler.removeCallbacks(releaseSttResourcesRunnable)
             handler.postDelayed(releaseSttResourcesRunnable, RELEASE_STT_RESOURCES_MILLIS)
-            sttInputDevice.tryLoad(::onInputEvent)
+            sttInputDevice.tryLoad(::onInputEvent, playSound)
         }
     }
 


### PR DESCRIPTION
## Summary
- process wake word regardless of case so commands trigger only after "Джарвис"
- restart listening silently when speech doesn't start with the wake word

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689062f2ea888321a54a649bdfe99847