### PR TITLE
Fix wake word handling and silence non-triggered speech

### DIFF
--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
@@ -8,7 +8,10 @@ import org.stypox.dicio.io.input.SttState
 class FakeSttInputDeviceWrapper : SttInputDeviceWrapper {
     override val uiState: MutableStateFlow<SttState> = MutableStateFlow(SttState.NotInitialized)
 
-    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean {
+    override fun tryLoad(
+        thenStartListeningEventListener: ((InputEvent) -> Unit)?,
+        playSound: Boolean,
+    ): Boolean {
         return true
     }
 


### PR DESCRIPTION
## Summary
- process wake word regardless of case so commands trigger only after "Джарвис"
- restart listening silently when speech doesn't start with the wake word
- fix SttService compile error by passing `thenStartListeningEventListener` to `tryLoad`
- suppress sounds during automatic resets to avoid periodic beeps

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689062f2ea888321a54a649bdfe99847