### PR TITLE
Expand eye expressions

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
@@ -107,12 +107,14 @@ fun rememberEyesState(): EyesState = remember { EyesState() }
  * @param state состояние глаз, позволяющее изменять эмоции
  * @param modifier модификатор для размещения компонента
  * @param eyeColor цвет глаз
+ * @param spacingRatio коэффициент расстояния между глазами
  */
 @Composable
 fun AnimatedEyes(
     state: EyesState,
     modifier: Modifier = Modifier,
     eyeColor: Color = Color.White,
+    spacingRatio: Float = 0.5f,
 ) {
     // Анимация моргания: значение 1 – глаза открыты, 0 – закрыты
     val blink = remember { Animatable(1f) }
@@ -140,8 +142,12 @@ fun AnimatedEyes(
             .height(30.dp)
     ) {
         val eyeSize = size.height
-        val leftCenter = Offset(size.width * 0.25f, size.height / 2f)
-        val rightCenter = Offset(size.width * 0.75f, size.height / 2f)
+        val gap = eyeSize * spacingRatio
+        val offset = eyeSize / 2f + gap / 2f
+        val centerY = size.height / 2f
+        val centerX = size.width / 2f
+        val leftCenter = Offset(centerX - offset, centerY)
+        val rightCenter = Offset(centerX + offset, centerY)
         drawEye(leftCenter, eyeSize, blink.value, state.expression, eyeColor)
         drawEye(rightCenter, eyeSize, blink.value, state.expression, eyeColor)
     }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.unit.dp
 import kotlin.math.min
 import kotlin.random.Random

--- a/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.random.Random
 import kotlinx.coroutines.delay
@@ -108,13 +109,16 @@ fun rememberEyesState(): EyesState = remember { EyesState() }
  * @param modifier модификатор для размещения компонента
  * @param eyeColor цвет глаз
  * @param spacingRatio коэффициент расстояния между глазами
- */
+ * @param eyeSize высота области рисования глаза. Меняя этот параметр,
+ *               можно масштабировать глаза без изменения логики рисования.
+*/
 @Composable
 fun AnimatedEyes(
     state: EyesState,
     modifier: Modifier = Modifier,
     eyeColor: Color = Color.White,
     spacingRatio: Float = 0.5f,
+    eyeSize: Dp = 120.dp,
 ) {
     // Анимация моргания: значение 1 – глаза открыты, 0 – закрыты
     val blink = remember { Animatable(1f) }
@@ -136,10 +140,12 @@ fun AnimatedEyes(
         }
     }
 
+    // Основное полотно для рисования глаз. Высота задаётся параметром [eyeSize],
+    // что позволяет менять масштаб глаз в различных режимах экрана.
     Canvas(
         modifier = modifier
             .fillMaxWidth()
-            .height(30.dp)
+            .height(eyeSize)
     ) {
         val eyeSize = size.height
         val gap = eyeSize * spacingRatio

--- a/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
@@ -191,13 +191,17 @@ private fun DrawScope.drawEye(
 
     val path = Path().apply {
         moveTo(topLeft.x, topLeft.y + radiusTop)
-        quadTo(topLeft.x, topLeft.y, topLeft.x + radiusTop, topLeft.y)
+        quadraticBezierTo(topLeft.x, topLeft.y, topLeft.x + radiusTop, topLeft.y)
         lineTo(topRight.x - radiusTop, topRight.y)
-        quadTo(topRight.x, topRight.y, topRight.x, topRight.y + radiusTop)
+        quadraticBezierTo(topRight.x, topRight.y, topRight.x, topRight.y + radiusTop)
         lineTo(bottomRight.x, bottomRight.y - radiusBottom)
-        quadTo(bottomRight.x, bottomRight.y, bottomRight.x - radiusBottom, bottomRight.y)
+        quadraticBezierTo(
+            bottomRight.x, bottomRight.y, bottomRight.x - radiusBottom, bottomRight.y
+        )
         lineTo(bottomLeft.x + radiusBottom, bottomLeft.y)
-        quadTo(bottomLeft.x, bottomLeft.y, bottomLeft.x, bottomLeft.y - radiusBottom)
+        quadraticBezierTo(
+            bottomLeft.x, bottomLeft.y, bottomLeft.x, bottomLeft.y - radiusBottom
+        )
         close()
     }
 

--- a/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/eyes/AnimatedEyes.kt
@@ -29,16 +29,24 @@ import kotlinx.coroutines.delay
  * Каждая эмоция определяет форму век и прочие элементы рисунка.
  */
 enum class EyeExpression {
-    /** Нейтральное спокойное выражение */
-    NEUTRAL,
-    /** Улыбка – верхние веки слегка опущены */
-    HAPPY,
-    /** Сердитый взгляд – верхние веки наклонены внутрь */
+    NORMAL,
     ANGRY,
-    /** Грустный взгляд – нижние веки приподняты */
+    GLEE,
+    HAPPY,
     SAD,
-    /** Удивление – глаза широко раскрыты */
+    WORRIED,
+    FOCUSED,
+    ANNOYED,
     SURPRISED,
+    SKEPTIC,
+    FRUSTRATED,
+    UNIMPRESSED,
+    SLEEPY,
+    SUSPICIOUS,
+    SQUINT,
+    FURIOUS,
+    SCARED,
+    AWE,
 }
 
 /**
@@ -47,7 +55,7 @@ enum class EyeExpression {
  */
 class EyesState {
     // Текущая эмоция хранится во внутреннем стейте
-    private var _expression by mutableStateOf(EyeExpression.NEUTRAL)
+    private var _expression by mutableStateOf(EyeExpression.NORMAL)
 
     /** Текущая эмоция глаз – доступна только для чтения */
     val expression: EyeExpression
@@ -150,8 +158,7 @@ private fun DrawScope.drawEye(
 
     // Рисуем веки в зависимости от эмоции
     when (expression) {
-        EyeExpression.HAPPY -> {
-            // Верхняя дуга, создающая "улыбку"
+        EyeExpression.HAPPY, EyeExpression.GLEE -> {
             drawArc(
                 color = pupilColor,
                 startAngle = 0f,
@@ -162,8 +169,7 @@ private fun DrawScope.drawEye(
                 style = Stroke(width = height * 0.15f, cap = StrokeCap.Round)
             )
         }
-        EyeExpression.ANGRY -> {
-            // Диагональная линия сверху-внутрь
+        EyeExpression.ANGRY, EyeExpression.FURIOUS -> {
             drawLine(
                 color = pupilColor,
                 start = Offset(rect.left, rect.top + height * 0.2f),
@@ -173,7 +179,6 @@ private fun DrawScope.drawEye(
             )
         }
         EyeExpression.SAD -> {
-            // Нижняя дуга "печали"
             drawArc(
                 color = pupilColor,
                 startAngle = 180f,
@@ -184,8 +189,7 @@ private fun DrawScope.drawEye(
                 style = Stroke(width = height * 0.15f, cap = StrokeCap.Round)
             )
         }
-        EyeExpression.SURPRISED -> {
-            // Толстая обводка вокруг глаза для эффекта удивления
+        EyeExpression.SURPRISED, EyeExpression.SCARED, EyeExpression.AWE -> {
             drawOval(
                 color = pupilColor.copy(alpha = 0.3f),
                 topLeft = rect.topLeft,

--- a/app/src/main/kotlin/org/stypox/dicio/ui/face/RobotFaceScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/face/RobotFaceScreen.kt
@@ -135,6 +135,7 @@ fun RobotFaceScreen(
 
         if (visibleOutput == null) {
             // Слушаем пользователя — глаза по центру
+            // Отображаем крупные глаза по центру, когда вывод скилла отсутствует
             RobotEyes(modifier = Modifier.align(Alignment.Center))
         } else {
             // Делим экран: глаза слева, вывод скилла справа
@@ -145,7 +146,9 @@ fun RobotFaceScreen(
                         .fillMaxHeight(),
                     contentAlignment = Alignment.Center
                 ) {
-                    RobotEyes()
+                    // При показе ответа скилла глаза занимают лишь половину экрана,
+                    // поэтому уменьшаем их размер для визуального баланса
+                    RobotEyes(compact = true)
                 }
                 Box(
                     modifier = Modifier
@@ -164,12 +167,22 @@ fun RobotFaceScreen(
  * Отображение пары анимированных глаз. Благодаря [rememberEyesState]
  * анимации и выбранная эмоция сохраняются между перерисовками.
  */
+/**
+ * Обёртка вокруг [AnimatedEyes], позволяющая переключать размер глаз.
+ * @param compact если `true`, глаза будут уменьшены и подойдут для режима,
+ *                когда экран поделён между глазами и выводом скилла
+ */
 @Composable
-fun RobotEyes(modifier: Modifier = Modifier) {
+fun RobotEyes(modifier: Modifier = Modifier, compact: Boolean = false) {
     val eyesState = rememberEyesState()
+
+    // В зависимости от режима выбираем высоту области рисования глаз.
+    // В обычном состоянии глаза крупнее (120dp), а в "компактном" режиме – меньше.
+    val size = if (compact) 60.dp else 120.dp
 
     AnimatedEyes(
         state = eyesState,
         modifier = modifier,
+        eyeSize = size,
     )
 }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/face/RobotFaceScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/face/RobotFaceScreen.kt
@@ -170,8 +170,6 @@ fun RobotEyes(modifier: Modifier = Modifier) {
 
     AnimatedEyes(
         state = eyesState,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(160.dp),
+        modifier = modifier,
     )
 }


### PR DESCRIPTION
## Summary
- extend eye expression enum with full set inspired by esp32-eyes
- map new expressions to existing animations (smile, angry, sad, surprised)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c017f21883219e9b6bb969583646