### PR TITLE
Avoid apostrophe in current date sentence

### DIFF
--- a/app/src/main/sentences/en/current_date.yml
+++ b/app/src/main/sentences/en/current_date.yml
@@ -1,6 +1,6 @@
 day:
   - (what day is it today)
-  - (what's the date today)
+  - what|(what s|is)|whats the? date today
 month:
   - (what month is it)
   - (which month is it)


### PR DESCRIPTION
## Summary
- remove apostrophe from current date English sentences to fix YAML parsing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4ccb6bc8321b364a26ad6742c91