### PR TITLE
Remove dicio-numbers dependency and add stub parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dicio uses [Vosk](https://github.com/alphacep/vosk-api/) as its speech to text (
 
 ## Contributing
 
-Dicio's code is **not only here**! The repository with the *compiler for sentences* language files is at [`dicio-sentences-compiler`](https://github.com/Stypox/dicio-sentences-compiler), the *number parser and formatter* is at [`dicio-numbers`](https://github.com/Stypox/dicio-numbers) and the code for evaluating matching algorithms is at [`dicio-evaluation`](https://github.com/Stypox/dicio-evaluation).
+Dicio's code is **not only here**! The repository with the *compiler for sentences* language files is at [`dicio-sentences-compiler`](https://github.com/Stypox/dicio-sentences-compiler) and the code for evaluating matching algorithms is at [`dicio-evaluation`](https://github.com/Stypox/dicio-evaluation).
 
 When contributing keep in mind that other people may have **needs** and **views different** than yours, so please *respect* them. For any question feel free to contact the project team at [@Stypox](https://github.com/Stypox).
 
@@ -107,7 +107,7 @@ The new skill most likely needs to interpret user input. The Dicio framework pro
               # Currently only string capturing groups are supported, but in
               # the future "number", "duration" and "date" will also be possible.
               # For the moment use "string" and then manually parse the string to
-              # number, duration or date using dicio-numbers.
+              # number, duration or date.
               type: string
     ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,6 @@ dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     // Dicio own libraries
-    implementation(libs.dicio.numbers)
     implementation(project(":skill"))
 
     // Android

--- a/app/src/main/kotlin/org/stypox/dicio/di/SkillContextImpl.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SkillContextImpl.kt
@@ -43,7 +43,7 @@ class SkillContextImpl private constructor(
                 lastParserFormatter = try {
                     Pair(ParserFormatter(currentLocale), currentLocale)
                 } catch (ignored: IllegalArgumentException) {
-                    // current locale is not supported by dicio-numbers
+                    // current locale is not supported by the parser
                     Pair(null, currentLocale)
                 }
             }

--- a/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsScreen.kt
@@ -57,12 +57,9 @@ import org.stypox.dicio.skills.search.SearchInfo
 import org.stypox.dicio.skills.weather.WeatherInfo
 import org.stypox.dicio.ui.theme.AppTheme
 import org.stypox.dicio.ui.util.SkillInfoPreviews
-import org.stypox.dicio.util.ShareUtils
 import org.stypox.dicio.util.getNonGrantedPermissions
 import org.stypox.dicio.util.commaJoinPermissions
 import org.stypox.dicio.util.requestAnyPermission
-
-const val DICIO_NUMBERS_LINK = "https://github.com/Stypox/dicio-numbers"
 
 @Composable
 fun SkillSettingsScreen(
@@ -94,24 +91,6 @@ fun SkillSettingsScreen(
         contentPadding = PaddingValues(top = 4.dp, bottom = 4.dp),
         modifier = modifier,
     ) {
-        if (viewModel.numberLibraryNotAvailable) {
-            item {
-                val context = LocalContext.current
-                Card(
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                    onClick = { ShareUtils.openUrlInBrowser(context, DICIO_NUMBERS_LINK) },
-                ) {
-                    Text(
-                        text = stringResource(R.string.pref_skill_number_library_not_available),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                    )
-                }
-            }
-        }
         items(skills) { skill ->
             SkillSettingsItem(
                 skill = skill,

--- a/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsViewModel.kt
@@ -31,8 +31,6 @@ class SkillSettingsViewModel @Inject constructor(
         .map { it.enabledSkillsMap }
         .toStateFlowDistinctBlockingFirst(viewModelScope)
 
-    val numberLibraryNotAvailable = skillContext.parserFormatter == null
-
     fun setSkillEnabled(id: String, state: Boolean) {
         viewModelScope.launch {
             dataStore.updateData {

--- a/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerSkill.kt
@@ -27,24 +27,24 @@ class TimerSkill(correspondingSkillInfo: SkillInfo, data: StandardRecognizerData
         // Определяем действие пользователя: установить, запросить или отменить таймер
         return when (inputData) {
             is Timer.Set -> {
-                val duration = inputData.duration?.value?.let {
+                val duration = inputData.duration?.let {
                     ctx.parserFormatter?.extractDuration(it)?.first?.toJavaDuration()
                 }
                 if (duration == null) {
                     // Пользователь не указал длительность, просим её
-                    TimerOutput.SetAskDuration { setTimer(ctx, it, inputData.name?.value) }
+                    TimerOutput.SetAskDuration { setTimer(ctx, it, inputData.name) }
                 } else {
-                    setTimer(ctx, duration, inputData.name?.value)
+                    setTimer(ctx, duration, inputData.name)
                 }
             }
             is Timer.Query -> {
-                queryTimer(ctx, inputData.name?.value)
+                queryTimer(ctx, inputData.name)
             }
             is Timer.Cancel -> {
                 if (inputData.name == null && SET_TIMERS.size > 1) {
                     TimerOutput.ConfirmCancel { cancelTimer(ctx, null) }
                 } else {
-                    cancelTimer(ctx, inputData.name?.value)
+                    cancelTimer(ctx, inputData.name)
                 }
             }
         }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerSkill.kt
@@ -27,24 +27,24 @@ class TimerSkill(correspondingSkillInfo: SkillInfo, data: StandardRecognizerData
         // Определяем действие пользователя: установить, запросить или отменить таймер
         return when (inputData) {
             is Timer.Set -> {
-                val duration = inputData.duration?.let {
+                val duration = inputData.duration?.value?.let {
                     ctx.parserFormatter?.extractDuration(it)?.first?.toJavaDuration()
                 }
                 if (duration == null) {
                     // Пользователь не указал длительность, просим её
-                    TimerOutput.SetAskDuration { setTimer(ctx, it, inputData.name) }
+                    TimerOutput.SetAskDuration { setTimer(ctx, it, inputData.name?.value) }
                 } else {
-                    setTimer(ctx, duration, inputData.name)
+                    setTimer(ctx, duration, inputData.name?.value)
                 }
             }
             is Timer.Query -> {
-                queryTimer(ctx, inputData.name)
+                queryTimer(ctx, inputData.name?.value)
             }
             is Timer.Cancel -> {
                 if (inputData.name == null && SET_TIMERS.size > 1) {
                     TimerOutput.ConfirmCancel { cancelTimer(ctx, null) }
                 } else {
-                    cancelTimer(ctx, inputData.name)
+                    cancelTimer(ctx, inputData.name?.value)
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,6 @@ debug-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 debug-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 # update versions for dicio-* libraries in settings.gradle.kts (they are included via git)
-dicio-numbers = { module = "git.included.build:dicio-numbers" }
 dicio-sentences-compiler = { module = "git.included.build:dicio-sentences-compiler" }
 dicio-sentences-compiler-plugin = { module = "org.stypox.dicio.sentencesCompilerPlugin:sentences-compiler-plugin" }
 exp4j = { module = "net.objecthunter:exp4j", version.ref = "exp4j" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,8 +34,8 @@ dependencyResolutionManagement {
 }
 
 
-// All of the code below handles depending on libraries from git repos, in particular dicio-numbers,
-// dicio-skill and dicio-sentences-compiler. The git commits to checkout can be updated here.
+// All of the code below handles depending on libraries from git repos, in particular
+// dicio-sentences-compiler. The git commits to checkout can be updated here.
 // If you want to use a local copy of the projects (provided that you have cloned them in
 // `../dicio-*`), you can add `useLocalDicioLibraries=true` in `local.properties`.
 
@@ -47,12 +47,6 @@ data class IncludeGitRepo(
 )
 
 val includeGitRepos = listOf(
-    IncludeGitRepo(
-        name = "dicio-numbers",
-        uri = "https://github.com/Stypox/dicio-numbers",
-        projectPath = ":numbers",
-        commit = "66fd44b79585f952b76d16e5578d4d6aa5bc030c",
-    ),
     IncludeGitRepo(
         name = "dicio-sentences-compiler",
         uri = "https://github.com/Stypox/dicio-sentences-compiler",

--- a/skill/README.md
+++ b/skill/README.md
@@ -1,7 +1,7 @@
 # Skills for Dicio assistant
 This tool provides an interface to create **multiplatform skills**. A skill is something that tries to provide an **answer to a request** from the user. It provides a fitness score based on user input (i.e. is it a query this skill is able to answer?) and provides the application using this library all of the needed data to respond to the user. A full skill is made up of **multiple separate components**, which process the data in a sort of *assembly line* to produce an output displayable to the user.
 
-This repository is part of the Dicio project. Also check out [`dicio-android`](https://github.com/Stypox/dicio-android), [`dicio-sentences-compiler`](https://github.com/Stypox/dicio-sentences-compiler/) and [`dicio-numbers`](https://github.com/Stypox/dicio-numbers). Open to contributions :-D
+This repository is part of the Dicio project. Also check out [`dicio-android`](https://github.com/Stypox/dicio-android) and [`dicio-sentences-compiler`](https://github.com/Stypox/dicio-sentences-compiler/). Open to contributions :-D
 
 ## Input recognizer
 An `InputRecognizer` is the first step in the *assembly line*, and it **processes input** from the user to determine if it **matches a given set of** (*custom*) **rules**, calculating a fitness score. The score is a value ranging from `0.0` to `1.0`, where 0 means "it does not match at all" and 1 means "it matches perfectly". Values between `0.85` and `1.0` usually describe a good match, while values below `0.7` are considered a bad match. When an input recognizer is evaluated as the most suitable one, it has to generate an object of type `ResultType` containing data extracted from the input, to be used in the next steps.

--- a/skill/build.gradle.kts
+++ b/skill/build.gradle.kts
@@ -41,9 +41,6 @@ tasks.withType<Test>().configureEach {
 }
 
 dependencies {
-    // dicio-numbers is needed to bring ParserFormatter into the classpath
-    implementation(libs.dicio.numbers)
-
     // Compose (check out https://developer.android.com/jetpack/compose/bom/bom-mapping)
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/skill/src/main/java/org/dicio/numbers/ParserFormatter.kt
+++ b/skill/src/main/java/org/dicio/numbers/ParserFormatter.kt
@@ -1,0 +1,110 @@
+package org.dicio.numbers
+
+import org.dicio.numbers.unit.Duration
+import org.dicio.numbers.unit.Number
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.Locale
+import java.time.Duration as JavaDuration
+
+/**
+ * Упрощённая заглушка исходного класса ParserFormatter из библиотеки dicio-numbers.
+ * Класс оставляет только необходимый для проекта интерфейс и не выполняет
+ * настоящего разбора текста или форматирования чисел.
+ *
+ * @param locale локаль, для которой предполагается выполнять операции.
+ */
+class ParserFormatter(private val locale: Locale) {
+    /**
+     * Пытается извлечь из строки длительность.
+     * В заглушке всегда возвращает пару из `null` и `null`, тем самым
+     * обозначая, что распознать длительность не удалось.
+     */
+    fun extractDuration(text: String): Pair<Duration?, String?> = Pair(null, null)
+
+    /**
+     * Форматирует переданную длительность в строку вида `HH:MM:SS`.
+     * Вся логика делегирована функции [javaDurationToString].
+     */
+    fun niceDuration(duration: Duration): NiceString =
+        NiceString(javaDurationToString(duration.toJavaDuration()))
+
+    /**
+     * Пытается распознать число в строке.
+     * Возвращает пустой результат, поскольку разбор не поддерживается.
+     */
+    fun extractNumber(text: String): Extraction = Extraction(emptyList())
+
+    /**
+     * Преобразует число в строку без какого‑либо специального форматирования.
+     */
+    fun niceNumber(number: Double): NiceString = NiceString(number.toString())
+
+    /**
+     * Возвращает строковое представление даты в ISO‑формате.
+     */
+    fun niceDate(date: LocalDate): NiceString = NiceString(date.toString())
+
+    /**
+     * Возвращает строку, содержащую только год из переданной даты.
+     */
+    fun niceYear(date: LocalDate): NiceString = NiceString(date.year.toString())
+
+    /**
+     * Возвращает строковое представление времени.
+     */
+    fun niceTime(time: LocalTime): NiceString = NiceString(time.toString())
+
+    /**
+     * Небольшой вспомогательный класс для имитации объекта, который может
+     * использоваться как обычная строка или как строка для озвучивания.
+     */
+    class NiceString(private val value: String) {
+
+        /**
+         * В заглушке флаг `speech` никак не используется, поэтому метод
+         * просто возвращает текущий экземпляр.
+         */
+        fun speech(@Suppress("UNUSED_PARAMETER") speech: Boolean): NiceString = this
+
+        /**
+         * Аналогично [speech], параметр `use24` игнорируется.
+         */
+        fun use24Hour(@Suppress("UNUSED_PARAMETER") use24: Boolean): NiceString = this
+
+        /** Возвращает сохранённую строку. */
+        fun get(): String = value
+    }
+
+    /**
+     * Результат попытки распознать число или длительность в тексте.
+     *
+     * @param mixedWithText список элементов, вперемешку с исходным текстом.
+     */
+    class Extraction(val mixedWithText: List<Any>) {
+
+        /**
+         * В заглушке метод ничего не делает и лишь возвращает текущий экземпляр.
+         */
+        fun preferOrdinal(@Suppress("UNUSED_PARAMETER") prefer: Boolean): Extraction = this
+    }
+
+    companion object {
+        /**
+         * Переводит [JavaDuration] в строку формата `HH:MM:SS`.
+         */
+        private fun javaDurationToString(d: JavaDuration): String {
+            val seconds = d.seconds
+            // Берём абсолютное значение для расчёта положительного формата
+            val absSeconds = kotlin.math.abs(seconds)
+            val positive = String.format(
+                "%d:%02d:%02d",
+                absSeconds / 3600,
+                (absSeconds % 3600) / 60,
+                absSeconds % 60
+            )
+            // Если длительность была отрицательной, добавляем знак минус
+            return if (seconds < 0) "-$positive" else positive
+        }
+    }
+}

--- a/skill/src/main/java/org/dicio/numbers/ParserFormatter.kt
+++ b/skill/src/main/java/org/dicio/numbers/ParserFormatter.kt
@@ -36,7 +36,13 @@ class ParserFormatter(private val locale: Locale) {
     fun extractNumber(text: String): Extraction = Extraction(emptyList())
 
     /**
-     * Преобразует число в строку без какого‑либо специального форматирования.
+     * Проговаривает число, возвращая его строковое представление без
+     * какого‑либо специального форматирования.
+     */
+    fun pronounceNumber(number: Double): NiceString = NiceString(number.toString())
+
+    /**
+     * Преобразует число в строку без дополнительного форматирования.
      */
     fun niceNumber(number: Double): NiceString = NiceString(number.toString())
 

--- a/skill/src/main/java/org/dicio/numbers/unit/Duration.kt
+++ b/skill/src/main/java/org/dicio/numbers/unit/Duration.kt
@@ -1,0 +1,17 @@
+package org.dicio.numbers.unit
+
+import java.time.Duration as JavaDuration
+
+/**
+ * Простейшая обёртка над [java.time.Duration], используемая заглушкой
+ * [org.dicio.numbers.ParserFormatter]. Никаких дополнительных вычислений не выполняется.
+ *
+ * @param javaDuration внутренняя длительность Java, которую мы храним.
+ */
+class Duration(private val javaDuration: JavaDuration) {
+
+    /**
+     * Возвращает сохранённый объект [JavaDuration] без изменений.
+     */
+    fun toJavaDuration(): JavaDuration = javaDuration
+}

--- a/skill/src/main/java/org/dicio/numbers/unit/Number.kt
+++ b/skill/src/main/java/org/dicio/numbers/unit/Number.kt
@@ -1,0 +1,27 @@
+package org.dicio.numbers.unit
+
+/**
+ * Минимальный числовой тип, обеспечивающий API, которого ждёт остальной код.
+ * Фактически это простая обёртка над `Double`.
+ *
+ * @param value числовое значение, которое хранится внутри.
+ */
+class Number(private val value: Double) {
+
+    /** Создаёт объект из целочисленного значения. */
+    constructor(value: Long) : this(value.toDouble())
+
+    /** Возвращает `true`, если число содержит дробную часть. */
+    val isDecimal: Boolean get() = value % 1.0 != 0.0
+    /** Возвращает `true`, если число целое. */
+    val isInteger: Boolean get() = !isDecimal
+
+    /** Возвращает значение в виде [Double]. */
+    fun decimalValue(): Double = value
+    /** Возвращает значение в виде [Long], отбрасывая дробную часть. */
+    fun integerValue(): Long = value.toLong()
+    /** Создаёт новое число, умноженное на [factor]. */
+    fun multiply(factor: Int): Number = Number(value * factor)
+    /** Проверяет, меньше ли число заданного [other]. */
+    fun lessThan(other: Int): Boolean = value < other
+}


### PR DESCRIPTION
## Summary
- drop dicio-numbers from build and settings
- add lightweight ParserFormatter/Number/Duration stubs with Russian comments
- remove number library warning from settings UI and docs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960858e26883219be075b19e1883e3